### PR TITLE
Use strings.TrimSuffix in func applyPolicies

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -219,7 +219,7 @@ func (r *syncCommand) applyPolicies(policies []string) error {
 	var list []string
 
 	for _, p := range policies {
-		name := strings.TrimRight(filepath.Base(p), filepath.Ext(filepath.Base(p)))
+		name := strings.TrimSuffix(filepath.Base(p), filepath.Ext(filepath.Base(p)))
 		list = append(list, name)
 
 		// step: read in the content


### PR DESCRIPTION
TrimRight would result in bug where the last letters could be omitted when
getting the policy name from the policy file name.
Ex: file: consul.hcl -> name: consu

Using strings.TrimSuffix fixes it.